### PR TITLE
minor CAN fixes

### DIFF
--- a/can.cpp
+++ b/can.cpp
@@ -43,8 +43,6 @@ void CanTxThread(void*)
 
         canTransmitTimeout(&CAND1, CAN_ANY_MAILBOX, &canTxMsg, TIME_INFINITE);
 
-        chThdSleepMilliseconds(CAN_TX_MSG_SPLIT);
-
         //=======================================================
         //Msg 1 (Analog input 5 millivolts and temperature)
         //=======================================================
@@ -57,8 +55,6 @@ void CanTxThread(void*)
         canTxMsg.data16[3] = GetTemperature();
 
         canTransmitTimeout(&CAND1, CAN_ANY_MAILBOX, &canTxMsg, TIME_INFINITE);
-
-        chThdSleepMilliseconds(CAN_TX_MSG_DELAY);
 
         //=======================================================
         //Msg 2 (Rotary switches, dig inputs, analog input switches, low side output status, heartbeat)

--- a/can.cpp
+++ b/can.cpp
@@ -93,7 +93,10 @@ static THD_FUNCTION(CanRxThread, p)
     {
         msg_t msg = canReceiveTimeout(&CAND1, CAN_ANY_MAILBOX, &canRxMsg, TIME_INFINITE);
         if (msg != MSG_OK)
+        {
             continue;
+        }
+
         if (canRxMsg.DLC >= 4)
         {
             SetDigOut(DigOut1, (bool)(canRxMsg.data8[0] & 0x01));
@@ -101,7 +104,6 @@ static THD_FUNCTION(CanRxThread, p)
             SetDigOut(DigOut3, (bool)(canRxMsg.data8[2] & 0x01));
             SetDigOut(DigOut4, (bool)(canRxMsg.data8[3] & 0x01));
         }
-        chThdSleepMilliseconds(10);
     }
 }
 

--- a/canboard_config.h
+++ b/canboard_config.h
@@ -6,5 +6,4 @@
 
 #define CAN_BASE_ID 0x640
 
-#define CAN_TX_MSG_DELAY 50
-#define CAN_TX_MSG_SPLIT 5
+#define CAN_TX_MSG_DELAY 100


### PR DESCRIPTION
- Don't sleep between sending CAN frames, just sleep once at the end
- Don't sleep between receiving CAN frames, just let it block on `canReceiveTimeout`
- Fix CAN filter initialization - assemble the `CANFilter` struct after setting `nCanBaseIdOffset`