### PR TITLE
adc uses a thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,7 @@ include $(CHIBIOS)/os/hal/hal.mk
 include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
 # RTOS files (optional).
 include $(CHIBIOS)/os/rt/rt.mk
-# Auto-build files in ./source recursively.
-include $(CHIBIOS)/tools/mk/autobuild.mk
-# Other files (optional).
-include $(CHIBIOS)/os/test/test.mk
-include $(CHIBIOS)/test/rt/rt_test.mk
-include $(CHIBIOS)/test/oslib/oslib_test.mk
+include $(CHIBIOS)/os/various/cpp_wrappers/chcpp.mk
 
 # include board.mk that sets per-board options
 include $(BOARDDIR)/board.mk

--- a/analog.cpp
+++ b/analog.cpp
@@ -53,10 +53,13 @@ struct AdcThread : chibios_rt::BaseStaticThread<256>
 {
     void main()
     {
-        adcConvert(&ADCD1, &adc1_cfg, adc1_samples, ADC1_BUF_DEPTH);
-        adcConvert(&ADCD2, &adc2_cfg, adc2_samples, ADC2_BUF_DEPTH);
+        while (true)
+        {
+            adcConvert(&ADCD1, &adc1_cfg, adc1_samples, ADC1_BUF_DEPTH);
+            adcConvert(&ADCD2, &adc2_cfg, adc2_samples, ADC2_BUF_DEPTH);
 
-        chThdSleepMilliseconds(10);
+            chThdSleepMilliseconds(10);
+        }
     }
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,5 @@
 #include "ch.h"
 #include "hal.h"
-#include "rt_test_root.h"
-#include "oslib_test_root.h"
 
 #include "canboard_config.h"
 #include "can.h"


### PR DESCRIPTION
- Remove test files from build (they're for testing ChibiOS itself)
- Add C++ wrappers to build
- Sample ADCs on a thread using `adcConvert` rather than free-running continuous conversion

This deserves a test on real hardware before merging.